### PR TITLE
Remove coverage artifact upload and add test results upload to Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,19 +58,11 @@ jobs:
       - name: Run tests
         run: |
           if [[ "${{ matrix.python-version }}" == "3.13" && "${{ matrix.os }}" == "ubuntu-latest" ]]; then
-            pytest --cov=src --cov-report=xml --cov-report=term
+            pytest --cov=src --cov-report=xml --cov-report=term --junitxml=junit.xml -o junit_family=legacy
           else
             pytest
           fi
         shell: bash
-
-      # Upload coverage report only on Python 3.13 + ubuntu.
-      - name: Upload coverage artifact
-        if: ${{ matrix.python-version == '3.13' && matrix.os == 'ubuntu-latest' }}
-        uses: actions/upload-artifact@v3
-        with:
-          name: coverage-report
-          path: coverage.xml
 
       # Upload to Codecov only on Python 3.13 + ubuntu.
       - name: Upload coverage report to Codecov
@@ -80,3 +72,11 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
           fail_ci_if_error: true
+
+      # Upload test results to Codecov only on Python 3.13 + ubuntu.
+      - name: Upload test results to Codecov
+        if: ${{ matrix.python-version == '3.13' && matrix.os == 'ubuntu-latest' && !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: junit.xml


### PR DESCRIPTION
This PR removes the upload of the coverage artifact, as the coverage report is already being uploaded directly to Codecov. Additionally, a step is added to upload the test results (in JUnit format) to Codecov. This ensures that test results are consistently captured and integrated into the Codecov report. The upload step will only occur if the workflow run has not been cancelled.